### PR TITLE
Set a higher lower bound on matrix dependency and disable lts-11 in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,9 +99,9 @@ matrix:
   #  compiler: ": #stack 8.0.2"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-11"
-    compiler: ": #stack 8.2.2"
-    addons: {apt: {packages: [libgmp-dev]}}
+  #- env: BUILD=stack ARGS="--resolver lts-11"
+  #  compiler: ": #stack 8.2.2"
+  #  addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-12"
     compiler: ": #stack 8.4.3"

--- a/markov-chain-usage-model.cabal
+++ b/markov-chain-usage-model.cabal
@@ -41,7 +41,7 @@ library
       -Wno-monomorphism-restriction
   build-depends:
       base >=4.10 && <5
-    , matrix >= 0.3.5.0
+    , matrix >= 0.3.6.1
     , vector >= 0.10
   default-language: Haskell2010
 


### PR DESCRIPTION
As otherwise doctests fail because of non-unicode pretty print.